### PR TITLE
get required status checks via github API

### DIFF
--- a/monors.py
+++ b/monors.py
@@ -197,6 +197,8 @@ class PullReq:
             logging.info ("no 'merge', 'squash' or 'rebase' command")
             return
 
+        logging.info ("Processing merge (method=%s) for PR %d" % (method, self.num))
+
         # structure:
         #  - key: context
         #  - value: Status
@@ -207,6 +209,10 @@ class PullReq:
             if status ["creator"]["login"].encode ("utf8") == self.cfg["user"].encode("utf8"):
                 if status ["context"] not in statuses or datetime.strptime (status ["updated_at"], "%Y-%m-%dT%H:%M:%SZ") > statuses [status ["context"]].updated_at:
                     statuses [status ["context"]] = Status (status ["state"].encode ("utf8"), datetime.strptime (status ["updated_at"], "%Y-%m-%dT%H:%M:%SZ"), status["description"], status["target_url"])
+
+        if not self.is_done (statuses):
+            logging.info ("PR builds are not done yet, skipping.")
+            return
 
         success = self.is_successful (statuses)
         if success is not True:

--- a/monors.py
+++ b/monors.py
@@ -83,17 +83,14 @@ class PullReq:
         self.title = self.info ["title"].encode ('utf8') if self.info ["title"] is not None else None
         self.body = self.info ["body"].encode ('utf8') if self.info ["body"] is not None else None
 
-        # TODO: load it from a configuration file?
-        self.mandatory_context = [
-            "Linux i386",
-            "Linux x64",
-            "Linux ARMv7",
-            "Linux AArch64",
-            "OS X i386",
-            "OS X x64",
-            "Windows i386",
-            "Windows x64",
-        ]
+        target_branch = self.info ['base']['ref']
+        contextes = self.gh.repos (cfg ["owner"]) (cfg ["repo"]).branches(target_branch).get() ['protection']['required_status_checks']['contexts']
+        self.mandatory_context = list ()
+
+        for c in contextes:
+            self.mandatory_context.append (c.encode("utf8"))
+
+        logging.info ("got mandatory_context from github: %s" % str(self.mandatory_context));
 
         logging.info ("----- loading %s" % (self.description ()))
 


### PR DESCRIPTION
looks like this:
```
INFO - found 100 pull requests
INFO - considering 50 pull requests
INFO - got mandatory_context from github: ['Linux x64', 'Linux x64 mcs', 'OS X i386', 'API Diff', 'license/cla', 'Linux AArch64', 'Linux i386', 'Linux x64 FullAOT', 'OS X x64', 'Linux AArch64 Interpreter', 'Linux x64 Interpreter', 'Linux i386 Coop GC', 'Linux x64 Coop GC']
INFO - ----- loading pull request https://github.com/mono/mono/pull/6960 - lewurm/mono/terminfo-v2 = f1361193 - '[TermInfo] support new file format terminfo2 introduced with ncurses6.1'
INFO - loading comments
INFO - no 'merge', 'squash' or 'rebase' command
INFO - no Slack token set up
```